### PR TITLE
[WIP]add: 商品一覧表示、imagesテーブルのカラムの変更

### DIFF
--- a/app/assets/stylesheets/modules/_main.scss
+++ b/app/assets/stylesheets/modules/_main.scss
@@ -48,6 +48,7 @@
         .item-box {
           margin: 0 0 0 20px;
           width: 213px;
+          height: 323px;
           position: relative;
           float: left;
           background: #fff;
@@ -64,17 +65,20 @@
               padding: 0 0 100%;
 
               &__img {
+                width: 100%;
+                height: auto;
                 position: absolute;
-                top: 0;
                 right: 0;
                 bottom: 0;
-                left: 0;
                 z-index: 1;
-                width: 100%;
+                object-fit: cover;
                 vertical-align: middle;
+                max-height: 213px;
+                top: 50%;
+                left: 50%;
+                transform: translate(-50%, -50%);
               }
             }
-          
 
             .item {
               height: 78px;

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,8 @@
 class ItemsController < ApplicationController
 
   def index
+    @items = Item.all.order("id DESC").limit(4)
+    @image = Image.all.order("id DESC").limit(4)
+    # @items = Item.includes(:image).page(params[:page]).per(4).order("created_at DESC")
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,6 +3,5 @@ class ItemsController < ApplicationController
   def index
     @items = Item.all.order("id DESC").limit(4)
     @image = Image.all.order("id DESC").limit(4)
-    # @items = Item.includes(:image).page(params[:page]).per(4).order("created_at DESC")
   end
 end

--- a/app/views/shared/_main.html.haml
+++ b/app/views/shared/_main.html.haml
@@ -13,45 +13,59 @@
         .item-box
           = link_to "#" do
             .photo
-              %img{src: "https://static.mercdn.net/thumb/photos/m33132342381_1.jpg?1559204933",class: "photo__img"}
+              = image_tag(@image[0].images,class: "photo__img")
 
             .item
-              .item__name LOEWE ロエベ ハンドバッグ レザー
+              .item__name
+                -# - @items.each do |item|
+                = @items[1].name
               .item__num
-                .item__price ¥ 14,000
+                .item__price
+                  -# - @items.each do |item|
+                  ¥
+                  = @items[1].price
               .item__tax (税込)
 
         .item-box
           = link_to "#" do
             .photo
-              %img{src: "https://static.mercdn.net/thumb/photos/m33132342381_1.jpg?1559204933",class: "photo__img"}
+              = image_tag(@image[1].images,class: "photo__img")
 
             .item
-              .item__name LOEWE ロエベ ハンドバッグ レザー
+              .item__name
+                = @items[0].name
               .item__num
-                .item__price ¥ 14,000
+                .item__price
+                  ¥ 
+                  = @items[0].price
               .item__tax (税込)
 
         .item-box
           = link_to "#" do
             .photo
-              %img{src: "https://static.mercdn.net/thumb/photos/m33132342381_1.jpg?1559204933",class: "photo__img"}
+              = image_tag(@image[2].images,class: "photo__img")
 
             .item
-              .item__name LOEWE ロエベ ハンドバッグ レザー
+              .item__name
+                = @items[3].name
               .item__num
-                .item__price ¥ 14,000
+                .item__price 
+                  ¥ 
+                  = @items[3].price
               .item__tax (税込)
 
         .item-box
           = link_to "#" do
             .photo
-              %img{src: "https://static.mercdn.net/thumb/photos/m33132342381_1.jpg?1559204933",class: "photo__img"}
+              = image_tag(@image[3].images,class: "photo__img")
 
             .item
-              .item__name LOEWE ロエベ ハンドバッグ レザー
+              .item__name
+                = @items[2].name
               .item__num
-                .item__price ¥ 14,000
+                .item__price
+                  ¥ 
+                  = @items[2].price
               .item__tax (税込)
 
       .view-all
@@ -68,45 +82,56 @@
         .item-box
           = link_to "#" do
             .photo
-              %img{src: "https://static.mercdn.net/thumb/photos/m87746425855_1.jpg?1559110856",class: "photo__img"}
-
+              = image_tag(@image[1].images,class: "photo__img")
             .item
-              .item__name AIR JORDAN 3 RETRO OG BG
+              .item__name
+                = @items[0].name
               .item__num
-                .item__price ¥ 10,000
+                .item__price
+                  ¥ 
+                  = @items[0].price
               .item__tax (税込)
 
         .item-box
           = link_to "#" do
             .photo
-              %img{src: "https://static.mercdn.net/thumb/photos/m87746425855_1.jpg?1559110856",class: "photo__img"}
-
+              = image_tag(@image[0].images,class: "photo__img")
             .item
-              .item__name AIR JORDAN 3 RETRO OG BG
+              .item__name
+
+                = @items[1].name
               .item__num
-                .item__price ¥ 10,000
+                .item__price
+                  ¥
+                  = @items[1].price
               .item__tax (税込)
 
         .item-box
           = link_to "#" do
             .photo
-              %img{src: "https://static.mercdn.net/thumb/photos/m87746425855_1.jpg?1559110856",class: "photo__img"}
+              = image_tag(@image[2].images,class: "photo__img")
 
             .item
-              .item__name AIR JORDAN 3 RETRO OG BG
+              .item__name
+                = @items[3].name
               .item__num
-                .item__price ¥ 10,000
+                .item__price 
+                  ¥ 
+                  = @items[3].price
               .item__tax (税込)
 
         .item-box
           = link_to "#" do
             .photo
-              %img{src: "https://static.mercdn.net/thumb/photos/m87746425855_1.jpg?1559110856",class: "photo__img"}
+              = image_tag(@image[3].images,class: "photo__img")
 
             .item
-              .item__name AIR JORDAN 3 RETRO OG BG
+              .item__name
+                = @items[2].name
               .item__num
-                .item__price ¥ 10,000
+                .item__price
+                  ¥ 
+                  = @items[2].price
               .item__tax (税込)
 
       .view-all

--- a/app/views/shared/_main.html.haml
+++ b/app/views/shared/_main.html.haml
@@ -17,11 +17,9 @@
 
             .item
               .item__name
-                -# - @items.each do |item|
                 = @items[1].name
               .item__num
                 .item__price
-                  -# - @items.each do |item|
                   ¥
                   = @items[1].price
               .item__tax (税込)

--- a/db/migrate/20190604080052_rename_item_column_to_images.rb
+++ b/db/migrate/20190604080052_rename_item_column_to_images.rb
@@ -1,0 +1,5 @@
+class RenameItemColumnToImages < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :images, :item, :item_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_03_041828) do
+ActiveRecord::Schema.define(version: 2019_06_04_080052) do
 
   create_table "brands", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name"
@@ -37,13 +37,15 @@ ActiveRecord::Schema.define(version: 2019_06_03_041828) do
 
   create_table "images", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.text "images"
-    t.bigint "item", null: false
+    t.bigint "item_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
   create_table "items", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "prefecture_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "name", null: false
     t.integer "price", null: false
     t.string "item_condition", null: false
@@ -54,8 +56,6 @@ ActiveRecord::Schema.define(version: 2019_06_03_041828) do
     t.string "shipping_rule", null: false
     t.bigint "user", null: false
     t.string "brand"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
   end
 
   create_table "items_categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -68,7 +68,6 @@ ActiveRecord::Schema.define(version: 2019_06_03_041828) do
   create_table "likes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "status", null: false
     t.bigint "item", null: false
-    t.bigint "user", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_04_080052) do
+ActiveRecord::Schema.define(version: 2019_06_04_040800) do
 
   create_table "brands", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name"
@@ -67,7 +67,7 @@ ActiveRecord::Schema.define(version: 2019_06_04_080052) do
 
   create_table "likes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "status", null: false
-    t.bigint "item", null: false
+    t.bigint "user", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end


### PR DESCRIPTION
# what
・商品一覧表示
　（カテゴリーの機能をまだつけていない状態なので、とりあえず今はitemsテーブルとimagesテーブルの中から最新の4つを引っ張ってきている状態です）

・imagesテーブルのitemカラムをitem_idカラムに変更
※単体テストは後ほど行います
# why
必要な機能の為

https://i.gyazo.com/522782300c638b8b3c93aed1844ad651.jpg
https://i.gyazo.com/25edd04d515709697729f5a526844570.jpg