### PR TITLE
[WIP]クレジットカード登録機能とビューファイルの紐付け

### DIFF
--- a/app/assets/stylesheets/modules/shared/_mypage-credit.scss
+++ b/app/assets/stylesheets/modules/shared/_mypage-credit.scss
@@ -1,0 +1,157 @@
+.mypage-pay-main {
+  background-color: white;
+  float: right;
+  width: 700px;
+  
+  .mypage-address-title {
+    font-size: 24px;
+    padding: 8px 24px;
+    text-align: center;
+    border-bottom: 1px solid #f5f5f5;
+    line-height: 1.4;
+    font-weight: bold;
+  }
+  .pay-box {
+    padding: 64px;
+    border-top: 1px solid #f5f5f5;
+    max-width: 320px;
+    margin: 0 auto;
+    .mypage-formGroup-first {
+      label {
+        font-weight: bold;
+      }
+      .mypage-form-arbitrary-required {
+        background: #ea352d;
+        margin: 0 0 0 8px;
+        padding: 2px 4px;
+        border-radius: 2px;
+        color: #fff;
+        font-size: 12px;
+        vertical-align: top;
+      }
+      .mypage-input-default {
+        width: 100%;
+        margin: 8px 0 0;
+        height: 28px;
+        padding: 10px 16px 8px;
+        border-radius: 4px;
+        border: 1px solid #ccc;
+        background: #fff;
+        line-height: 1.5;
+        font-size: 16px;
+      }
+      .mypage-signup-card-list {
+        margin: 8px 0 0;
+        font-size: 0;
+        .mypage-card-decoration {
+          display: inline-block;
+          vertical-align: middle;
+          margin: 0 0 0 6px;
+        }
+      } 
+    }
+    .mypage-formGroup-select {
+      margin: 40px 0 0;
+      .payment_card_expire {
+        font-weight: bold;
+      }
+      .mypage-form-arbitrary-required {
+        background: #ea352d;
+        margin: 0 0 0 8px;
+        padding: 2px 4px;
+        border-radius: 2px;
+        color: #fff;
+        font-size: 12px;
+        vertical-align: top;
+      }
+      .select-wrap {
+        display: inline-block;
+        width: 35%;
+        margin: 8px 0 0;
+        position: relative;
+        background: #fff;
+        .mypage-select-default {
+          width: 100%;
+          position: relative;
+          z-index: 2;
+          height: 48px;
+          padding: 0 16px;
+          border-radius: 4px;
+          border: 1px solid #ccc;
+          background: 0;
+          font-size: 16px;
+          line-height: 1.5;
+          cursor: pointer;
+          outline: 0;
+          -webkit-appearance: none;
+        }
+        .fa.fa-chevron-down.credit-mypage {
+          position: absolute;
+          right: 14px;
+          top: 30%;
+          z-index: 2;
+          color: #888;
+          font-size: 20px;
+        }
+      }
+      .mypage-credit-selectbox {
+        margin: 0 8px;
+      }
+    }
+    .mypage-formGroup {
+      margin: 40px 0 0;
+      label {
+        font-weight: bold;
+      }
+      .mypage-form-arbitrary-required {
+        background: #ea352d;
+        margin: 0 0 0 8px;
+        padding: 2px 4px;
+        border-radius: 2px;
+        color: #fff;
+        font-size: 12px;
+        vertical-align: top;
+      }
+      .mypage-input-default {
+        width: 100%;
+        margin: 8px 0 0;
+        height: 28px;
+        padding: 10px 16px 8px;
+        border-radius: 4px;
+        border: 1px solid #ccc;
+        background: #fff;
+        line-height: 1.5;
+        font-size: 16px;
+      }
+      .mypage-card-text_box {
+        position: relative;
+        margin: 8px 0 0;
+        .mypage-card-text {
+          text-align: right;
+          color: #0099e8;
+          .mypage-questionForm {
+            display: inline-block;
+            width: 14px;
+            height: 14px;
+            border-radius: 50%;
+            background: #0099e8;
+            color: #fff;
+            line-height: 14px;
+            font-size: 12px;
+            text-align: center;
+          }
+        }
+      }
+    }
+    .mypage-creditbtn {
+      margin: 40px 0 0;
+      background: #ea352d;
+      border: 1px solid #ea352d;
+      color: #fff;
+      display: block;
+      width: 100%;
+      line-height: 48px;
+      font-size: 14px;
+    }
+  }
+}

--- a/app/views/card/new.html.haml
+++ b/app/views/card/new.html.haml
@@ -1,39 +1,124 @@
-= form_tag(pay_card_index_path, method: :post, id: 'charge-form',  name: "inputForm") do
-  %label カード番号
-  = text_field_tag "number", "", class: "number", placeholder: "半角数字のみ" ,maxlength: "16", type: "text", id: "card_number"
-  %br
-  %label 有効期限
-  %select#exp_month{name: "exp_month", type: "text"}
-    %option{value: ""} --
-    %option{value: "1"}01
-    %option{value: "2"}02
-    %option{value: "3"}03
-    %option{value: "4"}04
-    %option{value: "5"}05
-    %option{value: "6"}06
-    %option{value: "7"}07
-    %option{value: "8"}08
-    %option{value: "9"}09
-    %option{value: "10"}10
-    %option{value: "11"}11
-    %option{value: "12"}12
-  %span 月/
-  %select#exp_year{name: "exp_year", type: "text"}
-    %option{value: ""} --
-    %option{value: "2019"}19
-    %option{value: "2020"}20
-    %option{value: "2021"}21
-    %option{value: "2022"}22
-    %option{value: "2023"}23
-    %option{value: "2024"}24
-    %option{value: "2025"}25
-    %option{value: "2026"}26
-    %option{value: "2027"}27
-    %option{value: "2028"}28
-    %option{value: "2029"}29
-  %span 年
-  %br
-  %label セキュリティコード
-  = text_field_tag "cvc", "", class: "cvc", placeholder: "カード背面3~4桁の番号", maxlength: "4", id: "cvc"
-  #card_token
-  = submit_tag "追加する", id: "token_submit"
+-# = form_tag(pay_card_index_path, method: :post, id: 'charge-form',  name: "inputForm") do
+-#   %label カード番号
+-#   = text_field_tag "number", "", class: "number", placeholder: "半角数字のみ" ,maxlength: "16", type: "text", id: "card_number"
+-#   %br
+-#   %label 有効期限
+-#   %select#exp_month{name: "exp_month", type: "text"}
+-#     %option{value: ""} --
+-#     %option{value: "1"}01
+-#     %option{value: "2"}02
+-#     %option{value: "3"}03
+-#     %option{value: "4"}04
+-#     %option{value: "5"}05
+-#     %option{value: "6"}06
+-#     %option{value: "7"}07
+-#     %option{value: "8"}08
+-#     %option{value: "9"}09
+-#     %option{value: "10"}10
+-#     %option{value: "11"}11
+-#     %option{value: "12"}12
+-#   %span 月/
+-#   %select#exp_year{name: "exp_year", type: "text"}
+-#     %option{value: ""} --
+-#     %option{value: "2019"}19
+-#     %option{value: "2020"}20
+-#     %option{value: "2021"}21
+-#     %option{value: "2022"}22
+-#     %option{value: "2023"}23
+-#     %option{value: "2024"}24
+-#     %option{value: "2025"}25
+-#     %option{value: "2026"}26
+-#     %option{value: "2027"}27
+-#     %option{value: "2028"}28
+-#     %option{value: "2029"}29
+-#   %span 年
+-#   %br
+-#   %label セキュリティコード
+-#   = text_field_tag "cvc", "", class: "cvc", placeholder: "カード背面3~4桁の番号", maxlength: "4", id: "cvc"
+-#   #card_token
+-#   = submit_tag "追加する", id: "token_submit"
+
+
+= render 'shared/header'
+.bread-crumbs
+  %ul
+    %li
+    -# 修正が必要
+    - breadcrumb :credit
+    = breadcrumbs separator: " #{content_tag(:i, '', class:'fa fa-chevron-right')} "
+.credit
+  = render 'shared/side_bar'
+
+  .mypage-pay-main
+    .mypage-address-title
+      %a.mypage-form-title クレジットカード情報入力
+    .pay-box
+      .mypage-formGroup-first
+        %label(for="zip_code") カード番号
+        %span.mypage-form-arbitrary-required 必須
+        %input(type="text" value="" name="zip_code" placeholder="半角数字のみ" class="mypage-input-default")
+        %ul.mypage-signup-card-list
+          %li.mypage-card-decoration
+            = image_tag(src="//www-mercari-jp.akamaized.net/assets/img/card/visa.svg?3270184656", width: "49", height: "20")
+          %li.mypage-card-decoration
+            = image_tag(src="//www-mercari-jp.akamaized.net/assets/img/card/master-card.svg?3270184656", width: "34", height: "20")
+          %li.mypage-card-decoration
+            = image_tag(src="//www-mercari-jp.akamaized.net/assets/img/card/saison-card.svg?3270184656", width: "30", height: "20")
+          %li.mypage-card-decoration
+            = image_tag(src="//www-mercari-jp.akamaized.net/assets/img/card/jcb.svg?3270184656", width: "32", height: "20")
+          %li.mypage-card-decoration
+            = image_tag(src="//www-mercari-jp.akamaized.net/assets/img/card/american_express.svg?3270184656", width: "21", height: "20")
+          %li.mypage-card-decoration
+            = image_tag(src="//www-mercari-jp.akamaized.net/assets/img/card/dinersclub.svg?3270184656", width: "32", height: "20")
+          %li.mypage-card-decoration
+            = image_tag(src="//www-mercari-jp.akamaized.net/assets/img/card/discover.svg?3270184656", width: "32", height: "20")
+      .mypage-formGroup-select
+        %label.payment_card_expire(for="zip_code") 有効期限
+        %span.mypage-form-arbitrary-required 必須
+        %br
+        .select-wrap
+          %select#payment_card_expire_mm.mypage-select-default
+            %option{value: "01"} 01
+            %option{value: "02"} 02
+            %option{value: "03"} 03
+            %option{value: "04"} 04
+            %option{value: "05"} 05
+            %option{value: "06"} 06
+            %option{value: "07"} 07
+            %option{value: "08"} 08
+            %option{value: "09"} 09
+            %option{value: "10"} 10
+            %option{value: "11"} 11
+            %option{value: "12"} 12
+          %i.fa.fa-chevron-down.credit-mypage
+        %span.mypage-credit-selectbox 月
+        %br
+        .select-wrap
+          %select#payment_card_expire_yy.mypage-select-default
+            %option{value: "19"} 19
+            %option{value: "20"} 20
+            %option{value: "21"} 21
+            %option{value: "22"} 22
+            %option{value: "23"} 23
+            %option{value: "24"} 24
+            %option{value: "25"} 25
+            %option{value: "26"} 26
+            %option{value: "27"} 27
+            %option{value: "28"} 28
+            %option{value: "29"} 29
+          %i.fa.fa-chevron-down.credit-mypage
+        %span.mypage-credit-selectbox 年
+      .mypage-formGroup
+        %label(for="zip_code") セキュリティコード
+        %span.mypage-form-arbitrary-required 必須
+        %input(type="text" value="" name="zip_code" placeholder="カード背面4桁もしくは3桁の番号" class="mypage-input-default")
+        .mypage-card-text_box
+          .mypage-card-text
+            %span.mypage-questionForm ?
+            カード裏面の番号とは？
+            %i.icon-arrow-right
+      %button(type="submit" class="mypage-creditbtn")追加する
+
+= render 'shared/aside'
+= render 'shared/footer'
+= render 'shared/footer-btn'

--- a/app/views/card/new.html.haml
+++ b/app/views/card/new.html.haml
@@ -49,75 +49,77 @@
 .credit
   = render 'shared/side_bar'
 
-  .mypage-pay-main
-    .mypage-address-title
-      %a.mypage-form-title クレジットカード情報入力
-    .pay-box
-      .mypage-formGroup-first
-        %label(for="zip_code") カード番号
-        %span.mypage-form-arbitrary-required 必須
-        %input(type="text" value="" name="zip_code" placeholder="半角数字のみ" class="mypage-input-default")
-        %ul.mypage-signup-card-list
-          %li.mypage-card-decoration
-            = image_tag(src="//www-mercari-jp.akamaized.net/assets/img/card/visa.svg?3270184656", width: "49", height: "20")
-          %li.mypage-card-decoration
-            = image_tag(src="//www-mercari-jp.akamaized.net/assets/img/card/master-card.svg?3270184656", width: "34", height: "20")
-          %li.mypage-card-decoration
-            = image_tag(src="//www-mercari-jp.akamaized.net/assets/img/card/saison-card.svg?3270184656", width: "30", height: "20")
-          %li.mypage-card-decoration
-            = image_tag(src="//www-mercari-jp.akamaized.net/assets/img/card/jcb.svg?3270184656", width: "32", height: "20")
-          %li.mypage-card-decoration
-            = image_tag(src="//www-mercari-jp.akamaized.net/assets/img/card/american_express.svg?3270184656", width: "21", height: "20")
-          %li.mypage-card-decoration
-            = image_tag(src="//www-mercari-jp.akamaized.net/assets/img/card/dinersclub.svg?3270184656", width: "32", height: "20")
-          %li.mypage-card-decoration
-            = image_tag(src="//www-mercari-jp.akamaized.net/assets/img/card/discover.svg?3270184656", width: "32", height: "20")
-      .mypage-formGroup-select
-        %label.payment_card_expire(for="zip_code") 有効期限
-        %span.mypage-form-arbitrary-required 必須
-        %br
-        .select-wrap
-          %select#payment_card_expire_mm.mypage-select-default
-            %option{value: "01"} 01
-            %option{value: "02"} 02
-            %option{value: "03"} 03
-            %option{value: "04"} 04
-            %option{value: "05"} 05
-            %option{value: "06"} 06
-            %option{value: "07"} 07
-            %option{value: "08"} 08
-            %option{value: "09"} 09
-            %option{value: "10"} 10
-            %option{value: "11"} 11
-            %option{value: "12"} 12
-          %i.fa.fa-chevron-down.credit-mypage
-        %span.mypage-credit-selectbox 月
-        %br
-        .select-wrap
-          %select#payment_card_expire_yy.mypage-select-default
-            %option{value: "19"} 19
-            %option{value: "20"} 20
-            %option{value: "21"} 21
-            %option{value: "22"} 22
-            %option{value: "23"} 23
-            %option{value: "24"} 24
-            %option{value: "25"} 25
-            %option{value: "26"} 26
-            %option{value: "27"} 27
-            %option{value: "28"} 28
-            %option{value: "29"} 29
-          %i.fa.fa-chevron-down.credit-mypage
-        %span.mypage-credit-selectbox 年
-      .mypage-formGroup
-        %label(for="zip_code") セキュリティコード
-        %span.mypage-form-arbitrary-required 必須
-        %input(type="text" value="" name="zip_code" placeholder="カード背面4桁もしくは3桁の番号" class="mypage-input-default")
-        .mypage-card-text_box
-          .mypage-card-text
-            %span.mypage-questionForm ?
-            カード裏面の番号とは？
-            %i.icon-arrow-right
-      %button(type="submit" class="mypage-creditbtn")追加する
+  = form_tag(pay_card_index_path, method: :post, id: 'charge-form',  name: "inputForm") do
+    .mypage-pay-main
+      .mypage-address-title
+        %a.mypage-form-title クレジットカード情報入力
+      .pay-box
+        .mypage-formGroup-first
+          %label カード番号
+          %span.mypage-form-arbitrary-required 必須
+          = text_field_tag "number", "", class: "mypage-input-default", placeholder: "半角数字のみ" ,maxlength: "16", type: "text", id: "card_number"
+          %ul.mypage-signup-card-list
+            %li.mypage-card-decoration
+              = image_tag(src="//www-mercari-jp.akamaized.net/assets/img/card/visa.svg?3270184656", width: "49", height: "20")
+            %li.mypage-card-decoration
+              = image_tag(src="//www-mercari-jp.akamaized.net/assets/img/card/master-card.svg?3270184656", width: "34", height: "20")
+            %li.mypage-card-decoration
+              = image_tag(src="//www-mercari-jp.akamaized.net/assets/img/card/saison-card.svg?3270184656", width: "30", height: "20")
+            %li.mypage-card-decoration
+              = image_tag(src="//www-mercari-jp.akamaized.net/assets/img/card/jcb.svg?3270184656", width: "32", height: "20")
+            %li.mypage-card-decoration
+              = image_tag(src="//www-mercari-jp.akamaized.net/assets/img/card/american_express.svg?3270184656", width: "21", height: "20")
+            %li.mypage-card-decoration
+              = image_tag(src="//www-mercari-jp.akamaized.net/assets/img/card/dinersclub.svg?3270184656", width: "32", height: "20")
+            %li.mypage-card-decoration
+              = image_tag(src="//www-mercari-jp.akamaized.net/assets/img/card/discover.svg?3270184656", width: "32", height: "20")
+        .mypage-formGroup-select
+          %label.payment_card_expire 有効期限
+          %span.mypage-form-arbitrary-required 必須
+          %br
+          .select-wrap
+            %select#exp_month{name: "exp_month", type: "text", class: "mypage-select-default"}
+              %option{value: "1"} 01
+              %option{value: "2"} 02
+              %option{value: "3"} 03
+              %option{value: "4"} 04
+              %option{value: "5"} 05
+              %option{value: "6"} 06
+              %option{value: "7"} 07
+              %option{value: "8"} 08
+              %option{value: "9"} 09
+              %option{value: "10"} 10
+              %option{value: "11"} 11
+              %option{value: "12"} 12
+            %i.fa.fa-chevron-down.credit-mypage
+          %span.mypage-credit-selectbox 月
+          %br
+          .select-wrap
+            %select#exp_year{name: "exp_year", type: "text", class: "mypage-select-default"}
+              %option{value: "2019"} 19
+              %option{value: "2020"} 20
+              %option{value: "2021"} 21
+              %option{value: "2022"} 22
+              %option{value: "2023"} 23
+              %option{value: "2024"} 24
+              %option{value: "2025"} 25
+              %option{value: "2026"} 26
+              %option{value: "2027"} 27
+              %option{value: "2028"} 28
+              %option{value: "2029"} 29
+            %i.fa.fa-chevron-down.credit-mypage
+          %span.mypage-credit-selectbox 年
+        .mypage-formGroup
+          %label セキュリティコード
+          %span.mypage-form-arbitrary-required 必須
+          = text_field_tag "cvc", "", class: "mypage-input-default", placeholder: "カード背面4桁もしくは3桁の番号", maxlength: "4", id: "cvc"
+          .mypage-card-text_box
+            .mypage-card-text
+              %span.mypage-questionForm ?
+              カード裏面の番号とは？
+              %i.icon-arrow-right
+        #card_token
+        = submit_tag "追加する", id: "token_submit", class: "mypage-creditbtn"
 
 = render 'shared/aside'
 = render 'shared/footer'

--- a/app/views/users/credit.html.haml
+++ b/app/views/users/credit.html.haml
@@ -16,7 +16,7 @@
           %ul.settingsPaymentList
         %section.settingsAddCard
           .singleContent
-            %a(href="https://www.mercari.com/jp/mypage/card/create/" class="btn")
+            = link_to '/card/new', class: "btn" do
               %i.fa.fa-credit-card
               クレジットカードを追加する
         .settingsNotRegist


### PR DESCRIPTION
# what
マイページの「支払い方法」から、クレジットカードの登録を行える様にしました。
card#newのルーティングを使用しています。
登録後に遷移するcard#showはタスク外となる為、仮のビューファイルで設定しています。

# why
購入機能を実装する上で必須である為。

https://gyazo.com/90c45cc39491de3d87a8b41facd6b39f