### PR TITLE
[WIP]add turbolinks road

### DIFF
--- a/app/assets/javascripts/payjp.js
+++ b/app/assets/javascripts/payjp.js
@@ -1,33 +1,35 @@
-document.addEventListener(
-  "DOMContentLoaded", e => {
-    if (document.getElementById("token_submit") != null) { //token_submitというidがnullの場合、下記コードを実行しない
-      Payjp.setPublicKey("pk_test_0aa6787c26ff6b071630a246"); //ここに公開鍵を直書き
-      let btn = document.getElementById("token_submit"); //IDがtoken_submitの場合に取得されます
-      btn.addEventListener("click", e => { //ボタンが押されたときに作動します
-        e.preventDefault(); //ボタンを一旦無効化します
-        let card = {
-          number: document.getElementById("card_number").value,
-          cvc: document.getElementById("cvc").value,
-          exp_month: document.getElementById("exp_month").value,
-          exp_year: document.getElementById("exp_year").value
-        }; //入力されたデータを取得します。
-        Payjp.createToken(card, (status, response) => {
-          if (status === 200) { //成功した場合
-            $("#card_number").removeAttr("name");
-            $("#cvc").removeAttr("name");
-            $("#exp_month").removeAttr("name");
-            $("#exp_year").removeAttr("name"); //データを自サーバにpostしないように削除
-            $("#card_token").append(
-              $('<input type="hidden" name="payjp-token">').val(response.id)
-            ); //取得したトークンを送信できる状態にします
-            document.inputForm.submit();
-            alert("登録が完了しました"); //確認用
-          } else {
-            alert("カード情報が正しくありません。"); //確認用
-          }
+// $(document).on('turbolinks:load', function(){
+  document.addEventListener(
+    "turbolinks:load", e => {
+      if (document.getElementById("token_submit") != null) { //token_submitというidがnullの場合、下記コードを実行しない
+        Payjp.setPublicKey("pk_test_0aa6787c26ff6b071630a246"); //ここに公開鍵を直書き
+        let btn = document.getElementById("token_submit"); //IDがtoken_submitの場合に取得されます
+        btn.addEventListener("click", e => { //ボタンが押されたときに作動します
+          e.preventDefault(); //ボタンを一旦無効化します
+          let card = {
+            number: document.getElementById("card_number").value,
+            cvc: document.getElementById("cvc").value,
+            exp_month: document.getElementById("exp_month").value,
+            exp_year: document.getElementById("exp_year").value
+          }; //入力されたデータを取得します。
+          Payjp.createToken(card, (status, response) => {
+            if (status === 200) { //成功した場合
+              $("#card_number").removeAttr("name");
+              $("#cvc").removeAttr("name");
+              $("#exp_month").removeAttr("name");
+              $("#exp_year").removeAttr("name"); //データを自サーバにpostしないように削除
+              $("#card_token").append(
+                $('<input type="hidden" name="payjp-token">').val(response.id)
+              ); //取得したトークンを送信できる状態にします
+              document.inputForm.submit();
+              alert("登録が完了しました"); //確認用
+            } else {
+              alert("カード情報が正しくありません。"); //確認用
+            }
+          });
         });
-      });
-    }
-  },
-  false
-);
+      }
+    },
+    false
+  );
+// });

--- a/app/assets/javascripts/payjp.js
+++ b/app/assets/javascripts/payjp.js
@@ -1,35 +1,34 @@
-// $(document).on('turbolinks:load', function(){
-  document.addEventListener(
-    "turbolinks:load", e => {
-      if (document.getElementById("token_submit") != null) { //token_submitというidがnullの場合、下記コードを実行しない
-        Payjp.setPublicKey("pk_test_0aa6787c26ff6b071630a246"); //ここに公開鍵を直書き
-        let btn = document.getElementById("token_submit"); //IDがtoken_submitの場合に取得されます
-        btn.addEventListener("click", e => { //ボタンが押されたときに作動します
-          e.preventDefault(); //ボタンを一旦無効化します
-          let card = {
-            number: document.getElementById("card_number").value,
-            cvc: document.getElementById("cvc").value,
-            exp_month: document.getElementById("exp_month").value,
-            exp_year: document.getElementById("exp_year").value
-          }; //入力されたデータを取得します。
-          Payjp.createToken(card, (status, response) => {
-            if (status === 200) { //成功した場合
-              $("#card_number").removeAttr("name");
-              $("#cvc").removeAttr("name");
-              $("#exp_month").removeAttr("name");
-              $("#exp_year").removeAttr("name"); //データを自サーバにpostしないように削除
-              $("#card_token").append(
-                $('<input type="hidden" name="payjp-token">').val(response.id)
-              ); //取得したトークンを送信できる状態にします
-              document.inputForm.submit();
-              alert("登録が完了しました"); //確認用
-            } else {
-              alert("カード情報が正しくありません。"); //確認用
-            }
-          });
+document.addEventListener(
+  "turbolinks:load", e => {
+    if (document.getElementById("token_submit") != null) { //token_submitというidがnullの場合、下記コードを実行しない
+      Payjp.setPublicKey("pk_test_0aa6787c26ff6b071630a246"); //ここに公開鍵を直書き
+      let btn = document.getElementById("token_submit"); //IDがtoken_submitの場合に取得されます
+      btn.addEventListener("click", e => { //ボタンが押されたときに作動します
+        e.preventDefault(); //ボタンを一旦無効化します
+        let card = {
+          number: document.getElementById("card_number").value,
+          cvc: document.getElementById("cvc").value,
+          exp_month: document.getElementById("exp_month").value,
+          exp_year: document.getElementById("exp_year").value
+        }; //入力されたデータを取得します。
+        Payjp.createToken(card, (status, response) => {
+          if (status === 200) { //成功した場合
+            $("#card_number").removeAttr("name");
+            $("#cvc").removeAttr("name");
+            $("#exp_month").removeAttr("name");
+            $("#exp_year").removeAttr("name"); //データを自サーバにpostしないように削除
+            $("#card_token").append(
+              $('<input type="hidden" name="payjp-token">').val(response.id)
+            ); //取得したトークンを送信できる状態にします
+            document.inputForm.submit();
+            alert("登録が完了しました"); //確認用
+          } else {
+            alert("カード情報が正しくありません。"); //確認用
+          }
         });
-      }
-    },
-    false
-  );
-// });
+      });
+    }
+  },
+  false
+);
+

--- a/app/views/users/credit.html.haml
+++ b/app/views/users/credit.html.haml
@@ -16,7 +16,7 @@
           %ul.settingsPaymentList
         %section.settingsAddCard
           .singleContent
-            = link_to '/card/new', class: "btn",data: {"turbolinks" => false} do
+            = link_to '/card/new', class: "btn" do
               %i.fa.fa-credit-card
               クレジットカードを追加する
         .settingsNotRegist


### PR DESCRIPTION
# what
pay.jpファイル内に、"turbolinks:load"を記述
credit.html.hamlファイル内からdata: {"turbolinks" => false}の記述を削除

#why
クレジットカード登録を、ページをリロードしなくても登録できるようにするため。