### PR TITLE
新規登録・ログイン画面への遷移修正

### DIFF
--- a/app/assets/stylesheets/modules/shared/_header.scss
+++ b/app/assets/stylesheets/modules/shared/_header.scss
@@ -139,6 +139,35 @@
           }
         }
       }
+      .logout-right {
+        float: right;
+        li {
+          float: right;
+          margin: 0 0 0 12px;
+          .login-btn {
+            background: #fff;
+            border: 1px solid #0099e8;
+            color: #0099e8;
+            float: right;
+            margin: 0 0 0 6px;
+            padding: 0 10px;
+            line-height: 30px;
+            border-radius: 4px;
+            text-align: center;
+          }
+          .registration-btn {
+            background: #ea352d;
+            border: 1px solid #ea352d;
+            color: #fff;
+            float: left;
+            margin: 0 0 0 6px;
+            padding: 0 10px;
+            line-height: 30px;
+            border-radius: 4px;
+            text-align: center;
+          }
+        }
+      }
     }
   }
 }
@@ -342,8 +371,7 @@
   
       &__bottom {
         margin: 8px 0 0;
-  
-        
+
           .left-btn--category {
             font-weight: bold;
             color: #333;

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,6 @@
 class ApplicationController < ActionController::Base
   before_action :basic_auth, if: :production?
   protect_from_forgery with: :exception
-  before_action :authenticate_user!
   before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :set_categories
 
@@ -26,7 +25,6 @@ class ApplicationController < ActionController::Base
   def set_categories
     @categories = Category.all
     @parents = Category.roots
-    # @children = @parents.map {|parent| parent.children}
   end
 
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,6 @@
 class ItemsController < ApplicationController
   require 'payjp'
+  before_action :authenticate_user!, except: :index
   before_action :set_item, only: [:show, :edit, :update, :destroy]
   before_action :set_search
 

--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -21,19 +21,29 @@
             = fa_icon 'tag',class: 'left-btn--brand__icon'
             %span ブランドから探す
 
-      %ul.right
-        %li.right-btn
-          = link_to root_path do
-            = fa_icon 'bell',class: 'right-btn__icon'
-            %span お知らせ
+      - if user_signed_in?
+        %ul.right
+          %li.right-btn
+            = link_to root_path do
+              = fa_icon 'bell',class: 'right-btn__icon'
+              %span お知らせ
+          %li.right-btn
+            = link_to root_path do
+              = fa_icon 'check',class: 'right-btn__icon'
+              %span やることリスト
+          %li.right-btn
+            = link_to user_path(current_user) do
+              %img{src:"//static.mercdn.net/images/member_photo_noimage_thumb.png", width: 32, class:"right-btn__mypage-icon"}
+              %span マイページ
+      - else
+        %ul.logout-right
+          %li
+            = link_to "ログイン", new_user_session_path, class: "login-btn"
+          %li
+            = link_to "新規会員登録", users_index_path, class: "registration-btn"
 
-        %li.right-btn
-          = link_to root_path do
-            = fa_icon 'check',class: 'right-btn__icon'
-            %span やることリスト
 
-        %li.right-btn
-          = link_to user_path(current_user) do
-            %img{src:"//static.mercdn.net/images/member_photo_noimage_thumb.png", width: 32, class:"right-btn__mypage-icon"}
-            %span マイページ
-            
+
+
+
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,10 @@
 Rails.application.routes.draw do
   devise_for :users, controllers: { omniauth_callbacks: 'users/omniauth_callbacks', registrations: 'users/registrations' }
+  
   devise_scope :user do
     get 'users/index', to: 'users/registrations#index'
   end
+  
   root 'items#index'
 
   resources :items do


### PR DESCRIPTION
# what
これまで非ログイン時は強制的にログイン画面に遷移していましたが、
ログインの状態に関わらずトップページに遷移するよう修正しました。

登録・ログインはヘッダー右上のボタンから遷移することができます。
また、エラーを防ぐ為、items#index以外のアクションに関してはログイン時のみ動くようにしています。

# why
画面遷移を本家のメルカリと同様のものにする為。

https://gyazo.com/44e0b2cdde16b456bab42aa9c2110357